### PR TITLE
Update Ruby to 3.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: jammy
 language: ruby
 
 rvm:
-  - 3.0.0
+  - 3.4.1
 
 before_install:
   - gem update --system

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,13 @@ ruby '>= 2.6'
 source 'https://rubygems.org'
 
 # Middleman
+gem 'base64'
+gem 'bigdecimal'
 gem 'middleman', '~> 4.4'
 gem 'middleman-syntax', '~> 3.2'
 gem 'middleman-autoprefixer', '~> 3.0'
 gem 'middleman-sprockets', '~> 4.1'
+gem 'mutex_m'
 gem 'rouge', '~> 3.21'
 gem 'redcarpet', '~> 3.6.0'
 gem 'nokogiri', '~> 1.13.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
     autoprefixer-rails (10.2.5.0)
       execjs (< 2.8.0)
     backports (3.23.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -82,6 +84,7 @@ GEM
       rouge (~> 3.2)
     mini_portile2 (2.8.0)
     minitest (5.17.0)
+    mutex_m (0.3.0)
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -128,10 +131,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
+  bigdecimal
   middleman (~> 4.4)
   middleman-autoprefixer (~> 3.0)
   middleman-sprockets (~> 4.1)
   middleman-syntax (~> 3.2)
+  mutex_m
   nokogiri (~> 1.13.3)
   redcarpet (~> 3.6.0)
   rouge (~> 3.21)
@@ -139,7 +145,7 @@ DEPENDENCIES
   webrick
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.4.1
 
 BUNDLED WITH
-   2.2.22
+   2.6.3


### PR DESCRIPTION
TravisCI builds started failing because the latest version of RubyGems requires a newer Ruby version that what we use.
```
$ gem update --system
Updating rubygems-update
ERROR:  Error installing rubygems-update:
	rubygems-update-3.6.3 requires Ruby version >= 3.1.0. The current ruby version is 3.0.0.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```
This PR updates Ruby to the latest version, 3.4.1. Branch build was successful https://app.travis-ci.com/github/SnapLogic/developer.snaplogic.com/builds/274181859.